### PR TITLE
feat(mail): add templates, SMTP transport and ops notify APIs (phase5…

### DIFF
--- a/.github/workflows/validate-places.yml
+++ b/.github/workflows/validate-places.yml
@@ -36,13 +36,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # === pnpm を公式アクションでセットアップ（v10想定） ===
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      # === Node と pnpm キャッシュを有効化 ===
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm@10
+          cache: pnpm
+
       - name: Install deps
         run: pnpm install --frozen-lockfile
+
       - name: Validate places (schema + business rules)
         run: pnpm run cpm:validate
 
@@ -51,13 +59,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm@10
+          cache: pnpm
+
       - name: Install deps
         run: pnpm install --frozen-lockfile
+
       - name: Validate submission patches
         run: pnpm run cpm:validate:submissions
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,27 @@
+# Node / Next.js
 node_modules
 .next
 out
-.env
-.env.*
 .DS_Store
 
-# backups
-components/0_*.tsx
-**/*.bak.*
-__backup__/
+# Env files
+.env
+.env.*
+!.env.example            # 例: .env.example はコミット許可
+!.env.schema             # 例: スキーマをコミット許可
+!.env.sample             # 例: サンプルをコミット許可
 
-# backups
-components/0_*.tsx
-**/*.bak.*
-__backup__/
+# Build / tool artifacts
+package-lock.json        # npmを使わない場合は無視
+# pnpm-lock.yaml         # pnpmを使うなら通常はコミット推奨（必要に応じて無視を外す）
 tools/verify/.last_summary.json
 tools/verify/last_runs.json
-package-lock.json
+
+# Local generated mail / submissions (任意: fileモード用の出力先)
+public/_mail/
+public/_submissions/
+
+# Backups
+components/0_*.tsx
+**/*.bak.*
+__backup__/

--- a/app/ops/notify/approved/route.ts
+++ b/app/ops/notify/approved/route.ts
@@ -1,4 +1,6 @@
 // app/ops/notify/approved/route.ts
+export const runtime = 'nodejs';
+
 import { NextResponse } from "next/server";
 import { buildMail } from "@/lib/mailerTemplates";
 import { sendMail } from "@/lib/mail";
@@ -8,10 +10,13 @@ export async function POST(req: Request) {
   try {
     const AUTH = process.env.OPS_NOTIFY_KEY;
     const key = req.headers.get("x-ops-key");
-    if (!AUTH || key !== AUTH) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    if (!AUTH || key !== AUTH) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
 
+    // expected body:
+    // { kind: 'owner'|'community', ref, approved_on, Business, Country, City, Category, public_url, submitterEmail }
     const body = await req.json();
-    // expected: { kind: 'owner' | 'community', ref, approved_on, Business, Country, City, Category, public_url, submitterEmail }
     const kind = body.kind as "owner" | "community";
     if (!kind) return NextResponse.json({ error: "kind required" }, { status: 400 });
 
@@ -24,6 +29,7 @@ export async function POST(req: Request) {
       Category: sanitizeText(body.Category),
       public_url: sanitizeText(body.public_url),
     });
+
     const to = sanitizeEmail(body.submitterEmail);
     if (!to) return NextResponse.json({ error: "submitterEmail required" }, { status: 400 });
 

--- a/app/ops/notify/approved/route.ts
+++ b/app/ops/notify/approved/route.ts
@@ -1,0 +1,36 @@
+// app/ops/notify/approved/route.ts
+import { NextResponse } from "next/server";
+import { buildMail } from "@/lib/mailerTemplates";
+import { sendMail } from "@/lib/mail";
+import { sanitizeText, sanitizeEmail } from "@/lib/sanitize";
+
+export async function POST(req: Request) {
+  try {
+    const AUTH = process.env.OPS_NOTIFY_KEY;
+    const key = req.headers.get("x-ops-key");
+    if (!AUTH || key !== AUTH) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+    const body = await req.json();
+    // expected: { kind: 'owner' | 'community', ref, approved_on, Business, Country, City, Category, public_url, submitterEmail }
+    const kind = body.kind as "owner" | "community";
+    if (!kind) return NextResponse.json({ error: "kind required" }, { status: 400 });
+
+    const mail = buildMail("user", kind, "approved", {
+      ref: sanitizeText(body.ref),
+      approved_on: sanitizeText(body.approved_on),
+      Business: sanitizeText(body.Business),
+      Country: sanitizeText(body.Country),
+      City: sanitizeText(body.City),
+      Category: sanitizeText(body.Category),
+      public_url: sanitizeText(body.public_url),
+    });
+    const to = sanitizeEmail(body.submitterEmail);
+    if (!to) return NextResponse.json({ error: "submitterEmail required" }, { status: 400 });
+
+    await sendMail({ to, subject: mail.subject, text: mail.text });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: "failed to send approved" }, { status: 500 });
+  }
+}

--- a/app/ops/notify/rejected/route.ts
+++ b/app/ops/notify/rejected/route.ts
@@ -1,0 +1,37 @@
+// app/ops/notify/rejected/route.ts
+import { NextResponse } from "next/server";
+import { buildMail } from "@/lib/mailerTemplates";
+import { sendMail } from "@/lib/mail";
+import { sanitizeText, sanitizeEmail } from "@/lib/sanitize";
+
+export async function POST(req: Request) {
+  try {
+    const AUTH = process.env.OPS_NOTIFY_KEY;
+    const key = req.headers.get("x-ops-key");
+    if (!AUTH || key !== AUTH) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+    const body = await req.json();
+    // expected: { kind: 'owner' | 'community', ref, reviewed_on, Business, reason, needed_fields, submitterEmail }
+    const kind = body.kind as "owner" | "community";
+    if (!kind) return NextResponse.json({ error: "kind required" }, { status: 400 });
+
+    const mail = buildMail("user", kind, "rejected", {
+      ref: sanitizeText(body.ref),
+      reviewed_on: sanitizeText(body.reviewed_on),
+      Business: sanitizeText(body.Business),
+      reason: sanitizeText(body.reason),
+      needed_fields: sanitizeText(body.needed_fields),
+      Country: sanitizeText(body.Country),
+      City: sanitizeText(body.City),
+      Category: sanitizeText(body.Category),
+    });
+    const to = sanitizeEmail(body.submitterEmail);
+    if (!to) return NextResponse.json({ error: "submitterEmail required" }, { status: 400 });
+
+    await sendMail({ to, subject: mail.subject, text: mail.text });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: "failed to send rejected" }, { status: 500 });
+  }
+}

--- a/app/ops/notify/rejected/route.ts
+++ b/app/ops/notify/rejected/route.ts
@@ -1,4 +1,6 @@
 // app/ops/notify/rejected/route.ts
+export const runtime = 'nodejs';
+
 import { NextResponse } from "next/server";
 import { buildMail } from "@/lib/mailerTemplates";
 import { sendMail } from "@/lib/mail";
@@ -8,10 +10,13 @@ export async function POST(req: Request) {
   try {
     const AUTH = process.env.OPS_NOTIFY_KEY;
     const key = req.headers.get("x-ops-key");
-    if (!AUTH || key !== AUTH) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    if (!AUTH || key !== AUTH) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
 
+    // expected body:
+    // { kind: 'owner'|'community', ref, reviewed_on, Business, reason, needed_fields, Country, City, Category, submitterEmail }
     const body = await req.json();
-    // expected: { kind: 'owner' | 'community', ref, reviewed_on, Business, reason, needed_fields, submitterEmail }
     const kind = body.kind as "owner" | "community";
     if (!kind) return NextResponse.json({ error: "kind required" }, { status: 400 });
 
@@ -25,6 +30,7 @@ export async function POST(req: Request) {
       City: sanitizeText(body.City),
       Category: sanitizeText(body.Category),
     });
+
     const to = sanitizeEmail(body.submitterEmail);
     if (!to) return NextResponse.json({ error: "submitterEmail required" }, { status: 400 });
 

--- a/app/ops/notify/report-resolution/route.ts
+++ b/app/ops/notify/report-resolution/route.ts
@@ -1,0 +1,32 @@
+// app/ops/notify/report-resolution/route.ts
+import { NextResponse } from "next/server";
+import { buildMail } from "@/lib/mailerTemplates";
+import { sendMail } from "@/lib/mail";
+import { sanitizeText, sanitizeEmail } from "@/lib/sanitize";
+
+export async function POST(req: Request) {
+  try {
+    const AUTH = process.env.OPS_NOTIFY_KEY;
+    const key = req.headers.get("x-ops-key");
+    if (!AUTH || key !== AUTH) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+    const body = await req.json();
+    // expected: { ref, SubmitterName, submitterEmail, resolutionEN, handled_on, resolution_detail, public_url }
+    const mail = buildMail("user", "report", "report_resolution", {
+      ref: sanitizeText(body.ref),
+      SubmitterName: sanitizeText(body.SubmitterName),
+      resolutionEN: sanitizeText(body.resolutionEN) as any,
+      handled_on: sanitizeText(body.handled_on),
+      resolution_detail: sanitizeText(body.resolution_detail),
+      public_url: sanitizeText(body.public_url),
+    });
+    const to = sanitizeEmail(body.submitterEmail);
+    if (!to) return NextResponse.json({ error: "submitterEmail required" }, { status: 400 });
+
+    await sendMail({ to, subject: mail.subject, text: mail.text });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: "failed to send report resolution" }, { status: 500 });
+  }
+}

--- a/app/ops/notify/report-resolution/route.ts
+++ b/app/ops/notify/report-resolution/route.ts
@@ -1,4 +1,6 @@
 // app/ops/notify/report-resolution/route.ts
+export const runtime = 'nodejs';
+
 import { NextResponse } from "next/server";
 import { buildMail } from "@/lib/mailerTemplates";
 import { sendMail } from "@/lib/mail";
@@ -8,10 +10,14 @@ export async function POST(req: Request) {
   try {
     const AUTH = process.env.OPS_NOTIFY_KEY;
     const key = req.headers.get("x-ops-key");
-    if (!AUTH || key !== AUTH) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    if (!AUTH || key !== AUTH) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
 
+    // expected body:
+    // { ref, SubmitterName, submitterEmail, resolutionEN, handled_on, resolution_detail, public_url }
     const body = await req.json();
-    // expected: { ref, SubmitterName, submitterEmail, resolutionEN, handled_on, resolution_detail, public_url }
+
     const mail = buildMail("user", "report", "report_resolution", {
       ref: sanitizeText(body.ref),
       SubmitterName: sanitizeText(body.SubmitterName),
@@ -20,6 +26,7 @@ export async function POST(req: Request) {
       resolution_detail: sanitizeText(body.resolution_detail),
       public_url: sanitizeText(body.public_url),
     });
+
     const to = sanitizeEmail(body.submitterEmail);
     if (!to) return NextResponse.json({ error: "submitterEmail required" }, { status: 400 });
 

--- a/app/submit/community/route.ts
+++ b/app/submit/community/route.ts
@@ -1,8 +1,8 @@
-// app/submit/owner/route.ts
+// app/submit/community/route.ts
 import { NextResponse } from "next/server";
 import { buildMail } from "@/lib/mailerTemplates";
 import { sendMail } from "@/lib/mail";
-import { sanitizeText, sanitizeEmail, sanitizeUrl } from "@/lib/sanitize";
+import { sanitizeText, sanitizeEmail } from "@/lib/sanitize";
 import { makeRef } from "@/lib/ref";
 import fs from "fs";
 import path from "path";
@@ -18,46 +18,47 @@ export async function POST(req: Request) {
     const City = sanitizeText(form.get("City") as string);
     const Category = sanitizeText(form.get("Category") as string);
     const AcceptedRaw = sanitizeText(form.get("Accepted") as string);
-    const website = sanitizeUrl(form.get("Website") as string); // 使うなら payload に追加可
-    const ownerVerifyUrl = sanitizeUrl(form.get("OwnerVerifyUrl") as string) || undefined;
+    const ImagesCount = Number(form.get("ImagesCount") ?? 0) || 0;
+    const EvidenceCount = Number(form.get("EvidenceCount") ?? 0) || 0;
 
-    const ref = makeRef("owner");
+    // 仕様：Evidence 2未満なら 400（必要なら有効化）
+    if (EvidenceCount < 2) {
+      return NextResponse.json({ error: "need at least 2 evidence images" }, { status: 400 });
+    }
 
+    const ref = makeRef("community");
     const payload = {
       ref,
       when: new Date().toISOString(),
       Business, Country, City, Category, AcceptedRaw,
-      ImagesCount: Number(form.get("ImagesCount") ?? 0) || 0,
+      ImagesCount, EvidenceCount,
       SubmitterName, SubmitterEmail,
-      owner_verify_url: ownerVerifyUrl,
     } as const;
 
     // user
-    const mailUser = buildMail("user", "owner", "receipt", payload);
     if (SubmitterEmail) {
+      const mailUser = buildMail("user", "community", "receipt", payload);
       await sendMail({ to: SubmitterEmail, subject: mailUser.subject, text: mailUser.text });
     }
 
     // ops
-    const mailOps = buildMail("ops", "owner", "receipt", payload);
+    const mailOps = buildMail("ops", "community", "receipt", payload);
     await sendMail({ to: "cryptopaymap.app@gmail.com", subject: mailOps.subject, text: mailOps.text });
 
-    // optional: local-only save
     if (process.env.SAVE_FILES === "1") {
-      const dir = path.join(process.cwd(), "public/_submissions/owner");
+      const dir = path.join(process.cwd(), "public/_submissions/community");
       fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(path.join(dir, `${ref}.json`), JSON.stringify(payload, null, 2));
     }
 
-    // 成功 → submitted.html にリダイレクト（クエリで ref と name）
     const url = new URL(req.url);
     url.pathname = "/submitted.html";
-    url.searchParams.set("kind", "owner");
+    url.searchParams.set("kind", "community");
     url.searchParams.set("ref", ref);
     url.searchParams.set("name", Business || SubmitterName || "—");
     return NextResponse.redirect(url, 303);
   } catch (e) {
     console.error(e);
-    return NextResponse.json({ error: "failed to submit owner" }, { status: 500 });
+    return NextResponse.json({ error: "failed to submit community" }, { status: 500 });
   }
 }

--- a/app/submit/community/route.ts
+++ b/app/submit/community/route.ts
@@ -1,11 +1,11 @@
 // app/submit/community/route.ts
+export const runtime = 'nodejs';
+
 import { NextResponse } from "next/server";
 import { buildMail } from "@/lib/mailerTemplates";
 import { sendMail } from "@/lib/mail";
 import { sanitizeText, sanitizeEmail } from "@/lib/sanitize";
 import { makeRef } from "@/lib/ref";
-import fs from "fs";
-import path from "path";
 
 export async function POST(req: Request) {
   try {
@@ -45,7 +45,10 @@ export async function POST(req: Request) {
     const mailOps = buildMail("ops", "community", "receipt", payload);
     await sendMail({ to: "cryptopaymap.app@gmail.com", subject: mailOps.subject, text: mailOps.text });
 
+    // optional: local-only save（Vercel本番では無効想定）— SAVE_FILES=1 の時のみ
     if (process.env.SAVE_FILES === "1") {
+      const { default: fs } = await import("fs");
+      const { default: path } = await import("path");
       const dir = path.join(process.cwd(), "public/_submissions/community");
       fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(path.join(dir, `${ref}.json`), JSON.stringify(payload, null, 2));

--- a/app/submit/report/route.ts
+++ b/app/submit/report/route.ts
@@ -1,0 +1,59 @@
+// app/submit/report/route.ts
+import { NextResponse } from "next/server";
+import { buildMail } from "@/lib/mailerTemplates";
+import { sendMail } from "@/lib/mail";
+import { sanitizeText, sanitizeEmail } from "@/lib/sanitize";
+import { makeRef } from "@/lib/ref";
+import fs from "fs";
+import path from "path";
+
+export async function POST(req: Request) {
+  try {
+    const form = await req.formData();
+
+    const SubmitterName = sanitizeText(form.get("SubmitterName") as string) || "Anonymous";
+    const SubmitterEmail = sanitizeEmail(form.get("SubmitterEmail") as string);
+    const issue_type = sanitizeText(form.get("IssueType") as string);
+    const place_ref = sanitizeText(form.get("PlaceRef") as string);
+    const description = sanitizeText(form.get("Description") as string);
+    const images_count = Number(form.get("ImagesCount") ?? 0) || 0;
+
+    // バリデーション例：Duplicate/Closed は説明必須
+    if ((/^(Duplicate|Closed)$/i).test(issue_type) && !description) {
+      return NextResponse.json({ error: "description is required for this issue type" }, { status: 400 });
+    }
+
+    const ref = makeRef("report");
+    const payload = {
+      ref,
+      when: new Date().toISOString(),
+      SubmitterName, SubmitterEmail, issue_type, place_ref, description, images_count,
+    } as const;
+
+    // user
+    if (SubmitterEmail) {
+      const mailUser = buildMail("user", "report", "receipt", payload);
+      await sendMail({ to: SubmitterEmail, subject: mailUser.subject, text: mailUser.text });
+    }
+
+    // ops
+    const mailOps = buildMail("ops", "report", "receipt", payload);
+    await sendMail({ to: "cryptopaymap.app@gmail.com", subject: mailOps.subject, text: mailOps.text });
+
+    if (process.env.SAVE_FILES === "1") {
+      const dir = path.join(process.cwd(), "public/_submissions/report");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, `${ref}.json`), JSON.stringify(payload, null, 2));
+    }
+
+    const url = new URL(req.url);
+    url.pathname = "/submitted.html";
+    url.searchParams.set("kind", "report");
+    url.searchParams.set("ref", ref);
+    url.searchParams.set("name", SubmitterName || "Anonymous");
+    return NextResponse.redirect(url, 303);
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: "failed to submit report" }, { status: 500 });
+  }
+}

--- a/fixtures/community.json
+++ b/fixtures/community.json
@@ -1,10 +1,7 @@
 {
-  "business_name": "Sample Diner",
-  "address": "1 Market St, San Francisco, CA",
-  "website": "https://diner.example",
-  "payments": "BTC / Lightning\nUSDT / eip155:137\nETH (EVM mainnet)",
-  "evidence_urls": "https://x.com/diner/status/1\nhttps://provider.example/merchant/abc",
-  "profile_summary": "Locals welcome.",
-  "gallery_urls": "https://user-images.githubusercontent.com/a.webp\nhttps://user-images.githubusercontent.com/b.webp",
-  "socials": "facebook https://facebook.com/diner"
+  "level": "community",
+  "payment": {
+    "accepts": ["BTC", "USDT", "ETH"]
+  }
 }
+

--- a/fixtures/owner.json
+++ b/fixtures/owner.json
@@ -1,11 +1,6 @@
 {
-  "business_name": "Example Coffee",
-  "address": "350 5th Ave, New York, NY 10118, USA",
-  "website": "https://example.com",
-  "payments": "- BTC (Lightning)\n- BTC (Bitcoin)\n- ETH (Ethereum Mainnet)\n- USDT / Polygon",
-  "payment_pages": "https://example.com/pay\nhttps://btcpay.example.com/merchant/123",
-  "owner_proof": "Domain verification",
-  "profile_summary": "We accept Bitcoin (Lightning) and Ethereum.",
-  "gallery_urls": "https://user-images.githubusercontent.com/img1.webp\nhttps://user-images.githubusercontent.com/img2.webp",
-  "socials": "x https://x.com/example\ninstagram @coffee"
+  "level": "owner",
+  "payment": {
+    "accepts": ["BTC", "ETH", "USDT"]
+  }
 }

--- a/fixtures/report.json
+++ b/fixtures/report.json
@@ -1,7 +1,3 @@
 {
-  "place_id_or_url": "us-nyc-abc123",
-  "details": "Wrong coin list on the card.",
-  "proposed_status": "disputed",
-  "evidence_urls": "https://example.com/notice\nhttps://x.com/user/status/2",
-  "images": "https://user-images.githubusercontent.com/r.webp"
+  "level": "unverified"
 }

--- a/scripts/testMailer.ts
+++ b/scripts/testMailer.ts
@@ -1,0 +1,62 @@
+// scripts/testMailer.ts
+import "dotenv/config";
+
+function die(e: unknown): never {
+  // 失敗を必ず可視化
+  console.error("❌ Fatal:", e);
+  if (e instanceof Error && e.stack) console.error(e.stack);
+  process.exit(1);
+}
+
+(async () => {
+  console.log("=== testMailer: start ===");
+  console.log("CWD:", process.cwd());
+  console.log("MAIL_TRANSPORT:", process.env.MAIL_TRANSPORT ?? "(unset, default console)");
+  console.log("NODE_VERSION:", process.version);
+
+  let buildMail: any;
+  let sendMail: any;
+  try {
+    ({ buildMail } = await import("../src/lib/mailerTemplates"));
+    ({ sendMail } = await import("../src/lib/mail"));
+  } catch (e) {
+    die(e);
+  }
+
+  const to = process.env.TEST_MAIL_TO ?? "test@example.com";
+  const payload = {
+    ref: "owner-20251021-0001",
+    when: new Date().toISOString(),
+    Business: "South Pole Coffee",
+    Country: "Antarctica",
+    City: "McMurdo Station",
+    Category: "Cafe",
+    AcceptedRaw: "BTC, USDT",
+    ImagesCount: 2,
+    SubmitterName: "Alice",
+    SubmitterEmail: "alice@example.com",
+    // owner_verify_url: "https://example.com/verify/owner-20251021-0001",
+  } as const;
+
+  console.log("=== building mail (user/owner/receipt) ===");
+  const mail = buildMail("user", "owner", "receipt", payload);
+
+  console.log("--- SUBJECT ---");
+  console.log(mail.subject);
+  console.log("--- BODY ---");
+  console.log(mail.text);
+
+  console.log("=== sending via sendMail() ===");
+  try {
+    await sendMail({
+      to,
+      subject: mail.subject,
+      text: mail.text,
+    });
+    console.log("✅ sendMail() completed");
+  } catch (e) {
+    die(e);
+  }
+
+  console.log("=== testMailer: done ===");
+})();

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -1,29 +1,84 @@
-import nodemailer from "nodemailer";
-import fs from "fs/promises";
+// src/lib/mail.ts
+import fs from "fs";
 import path from "path";
+import nodemailer from "nodemailer";
+import { MailContent } from "./mailerTemplates";
 
-type MailInput = { to: string | string[]; subject: string; text: string; html?: string };
-const MODE = process.env.MAIL_TRANSPORT ?? "console"; // smtp|file|console
-const FROM = process.env.MAIL_FROM || "no-reply@example.com";
-const OUT = process.env.MAIL_OUT_DIR || "public/_mail";
+/**
+ * Send mail via selected transport (console / file / smtp)
+ *
+ * Environment variables:
+ *   MAIL_TRANSPORT = console | file | smtp
+ *   // SMTP/MAIL の両系統に対応（どちらでも可・SMTP_* 優先）
+ *   SMTP_HOST / MAIL_HOST
+ *   SMTP_PORT / MAIL_PORT
+ *   SMTP_USER / MAIL_USER
+ *   SMTP_PASS / MAIL_PASS
+ *   SMTP_SECURE / MAIL_SECURE  (true/false)
+ *   MAIL_FROM
+ *   MAIL_OUT_DIR (file mode only)
+ */
+export async function sendMail({
+  to,
+  subject,
+  text,
+  quiet,
+}: MailContent & { to: string; quiet?: boolean }): Promise<void> {
+  const mode = process.env.MAIL_TRANSPORT ?? "console";
+  const from = process.env.MAIL_FROM ?? "CryptoPayMap <no-reply@cryptopaymap.app>";
 
-export async function sendMail({ to, subject, text, html }: MailInput) {
-  if (MODE === "smtp") {
-    const transport = nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: Number(process.env.SMTP_PORT || 587),
-      secure: String(process.env.SMTP_SECURE || "false") === "true",
-      auth: process.env.SMTP_USER ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS } : undefined,
-    } as any);
-    await transport.sendMail({ from: FROM, to, subject, text, html });
+  if (mode === "console") {
+    if (!quiet) {
+      console.log("----- MAIL (console mode) -----");
+      console.log("To:", to);
+      console.log("From:", from);
+      console.log("Subject:", subject);
+      console.log("Body:\n" + text);
+      console.log("-------------------------------");
+    }
     return;
   }
-  const body = [`Subject: ${subject}`, `To: ${Array.isArray(to) ? to.join(",") : to}`, "", text].join("\n");
-  if (MODE === "file") {
-    await fs.mkdir(OUT, { recursive: true }).catch(()=>{});
-    const fn = path.join(OUT, `${Date.now()}.${subject.replace(/\W+/g,"_")}.txt`);
-    await fs.writeFile(fn, body, "utf8");
+
+  if (mode === "file") {
+    const outDir = process.env.MAIL_OUT_DIR || "public/_mail";
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const filePath = path.join(outDir, `mail-${ts}.txt`);
+    fs.mkdirSync(outDir, { recursive: true });
+    const content = [`To: ${to}`, `From: ${from}`, `Subject: ${subject}`, "", text].join("\n");
+    fs.writeFileSync(filePath, content, "utf-8");
+    if (!quiet) console.log(`📩 Mail saved to ${filePath}`);
     return;
   }
-  console.log("=== MAIL (console) ===\n" + body + "\n======================");
+
+  if (mode === "smtp") {
+    // ---- 優先順：SMTP_* → MAIL_* ----
+    const host = process.env.SMTP_HOST || process.env.MAIL_HOST;
+    const portStr = process.env.SMTP_PORT || process.env.MAIL_PORT;
+    const user = process.env.SMTP_USER || process.env.MAIL_USER;
+    const pass = process.env.SMTP_PASS || process.env.MAIL_PASS;
+    const secureStr = process.env.SMTP_SECURE ?? process.env.MAIL_SECURE;
+
+    const port = Number(portStr ?? 465);
+    const secure = typeof secureStr === "string"
+      ? secureStr === "true"
+      : port === 465; // 465=SMTPS、587=STARTTLS
+
+    if (!host || !user || !pass) {
+      throw new Error("Missing SMTP credentials. Set SMTP_* (or MAIL_*) variables.");
+    }
+
+    const transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure,           // 587 なら false（STARTTLS を自動利用）
+      auth: { user, pass },
+    });
+
+    await transporter.sendMail({ from, to, subject, text });
+
+    if (!quiet) console.log(`✅ SMTP mail sent to ${to}`);
+    return;
+  }
+
+  throw new Error(`Unknown MAIL_TRANSPORT mode: ${mode}`);
 }

--- a/src/lib/mailerTemplates.ts
+++ b/src/lib/mailerTemplates.ts
@@ -1,0 +1,328 @@
+// src/lib/mailerTemplates.ts
+// CryptoPayMap — English email templates (Owner / Community / Report)
+// Actions:
+//   - 'receipt'           -> user & ops (owner/community/report)
+//   - 'approved'          -> user        (owner/community)
+//   - 'rejected'          -> user        (owner/community)
+//   - 'report_resolution' -> user        (report)
+// Audience: 'user' | 'ops'
+
+export type Kind = 'owner' | 'community' | 'report';
+export type Action = 'receipt' | 'approved' | 'rejected' | 'report_resolution';
+export type Audience = 'user' | 'ops';
+
+export interface MailPayload {
+  ref: string;
+  when?: string;
+  approved_on?: string;
+  reviewed_on?: string;
+  handled_on?: string;
+
+  // business/place info (owner/community)
+  Business?: string;
+  Country?: string;
+  City?: string;
+  Category?: string;
+  AcceptedRaw?: string;
+  ImagesCount?: number;
+
+  // community-only
+  EvidenceCount?: number;
+
+  // links
+  public_url?: string;
+  owner_verify_url?: string; // show to user & ops when available (owner only)
+
+  // rejection
+  reason?: string;
+  needed_fields?: string;
+
+  // report
+  SubmitterName?: string;
+  SubmitterEmail?: string;
+  issue_type?: string;
+  place_ref?: string;
+  description?: string;
+  images_count?: number;
+
+  // resolution
+  resolutionEN?: 'Resolved' | 'Rejected' | 'Duplicate';
+  resolution_detail?: string;
+}
+
+export interface MailContent {
+  subject: string;
+  text: string; // plain text
+}
+
+const divider = '────────────────────────';
+const footer =
+  `${divider}
+CryptoPayMap Operations Team
+cryptopaymap.app@gmail.com`; // Footer: team label + ops email only
+
+const kindEN = (k: Kind) =>
+  k === 'owner' ? 'Owner Submission' : k === 'community' ? 'Community Submission' : 'Report';
+
+function ensure(cond: unknown, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+function greetUser(p: MailPayload): string {
+  const name = p.Business || p.SubmitterName || 'User';
+  return `Dear ${name},`;
+}
+
+/* =========================
+ * USER — OWNER/COMMUNITY
+ * ========================= */
+function ocUserReceipt(kind: Exclude<Kind, 'report'>, p: MailPayload): MailContent {
+  ensure(p.ref, 'ref required');
+  // fix: avoid "Submission Submission"
+  const subject = `[CryptoPayMap] ${kindEN(kind)} Received (Ref: ${p.ref})`;
+  const lines = [
+    greetUser(p),
+    '',
+    // slightly more natural phrasing
+    `Thank you for your ${kindEN(kind)} to CryptoPayMap.`,
+    'Your request has been received with the following details:',
+    '',
+    divider,
+    `Reference ID: ${p.ref}`,
+    `Submission Type: ${kindEN(kind)}`,
+    `Received On: ${p.when ?? '—'}`,
+    `Business Name: ${p.Business ?? '—'}`,
+    `Location: ${p.Country ?? '—'} / ${p.City ?? '—'}`,
+    `Category: ${p.Category ?? '—'}`,
+    `Accepted Currencies: ${p.AcceptedRaw ?? '—'}`,
+    `Image Count: ${p.ImagesCount ?? 0}`,
+    kind === 'community' ? `Evidence Images: ${p.EvidenceCount ?? 0}` : null,
+    kind === 'owner' && p.owner_verify_url ? `Owner Verification URL: ${p.owner_verify_url}` : null,
+    divider,
+    '',
+    'Our team will review your submission. Once approved, it will appear on CryptoPayMap.',
+    '',
+    'This is an automated message. If you did not submit this request,',
+    'please contact cryptopaymap.app@gmail.com.',
+    '',
+    footer,
+  ].filter(Boolean) as string[];
+  return { subject, text: lines.join('\n') };
+}
+
+function ocUserApproved(kind: Exclude<Kind, 'report'>, p: MailPayload): MailContent {
+  ensure(p.ref, 'ref required');
+  const subject = `[CryptoPayMap] Your ${kindEN(kind)} Has Been Approved (Ref: ${p.ref})`;
+  const lines = [
+    greetUser(p),
+    '',
+    `Your ${kindEN(kind)} has been reviewed and approved. Details below:`,
+    '',
+    divider,
+    `Reference ID: ${p.ref}`,
+    `Approved On: ${p.approved_on ?? '—'}`,
+    `Business Name: ${p.Business ?? '—'}`,
+    `Location: ${p.Country ?? '—'} / ${p.City ?? '—'}`,
+    `Category: ${p.Category ?? '—'}`,
+    `Public URL: ${p.public_url ?? '—'}`,
+    divider,
+    '',
+    'If you need to request corrections or updates, please submit a new request via the form.',
+    '',
+    footer,
+  ];
+  return { subject, text: lines.join('\n') };
+}
+
+function ocUserRejected(kind: Exclude<Kind, 'report'>, p: MailPayload): MailContent {
+  ensure(p.ref, 'ref required');
+  const subject = `[CryptoPayMap] Your ${kindEN(kind)} Was Not Approved (Ref: ${p.ref})`;
+  const lines = [
+    greetUser(p),
+    '',
+    `After reviewing your ${kindEN(kind)}, we’re sorry to inform you it was not approved.`,
+    '',
+    divider,
+    `Reference ID: ${p.ref}`,
+    `Reviewed On: ${p.reviewed_on ?? '—'}`,
+    `Reason: ${p.reason ?? '—'}`,
+    `Required Fixes: ${p.needed_fields ?? '—'}`,
+    divider,
+    '',
+    'Please correct the items above and resubmit your application via the form.',
+    '',
+    footer,
+  ];
+  return { subject, text: lines.join('\n') };
+}
+
+/* =========================
+ * OPS — OWNER/COMMUNITY
+ * ========================= */
+function ocOpsReceipt(kind: Exclude<Kind, 'report'>, p: MailPayload): MailContent {
+  ensure(p.ref, 'ref required');
+  const subject = `[OPS] New ${kind} submission received (${p.ref})`;
+  const lines = [
+    `Ref: ${p.ref}`,
+    `When: ${p.when ?? '—'}`,
+    `Submitter: ${p.SubmitterName ?? '—'}${p.SubmitterEmail ? ` <${p.SubmitterEmail}>` : ''}`,
+    `Business/Place: ${p.Business ?? '—'}`,
+    `Country/City: ${p.Country ?? '—'} / ${p.City ?? '—'}`,
+    `Category: ${p.Category ?? '—'}`,
+    `Accepted (raw): ${p.AcceptedRaw ?? '—'}`,
+    `Images count: ${p.ImagesCount ?? 0}`,
+    kind === 'owner' && p.owner_verify_url ? `Owner verification URL: ${p.owner_verify_url}` : null,
+    kind === 'community' ? `Evidence count: ${p.EvidenceCount ?? 0}` : null,
+  ].filter(Boolean) as string[];
+  return { subject, text: lines.join('\n') };
+}
+
+/* =========================
+ * USER — REPORT
+ * ========================= */
+function reportUserReceipt(p: MailPayload): MailContent {
+  ensure(p.ref, 'ref required');
+  const subject = `[CryptoPayMap] Report Received (Ref: ${p.ref})`;
+  const lines = [
+    `Dear ${p.SubmitterName ?? 'User'},`,
+    '',
+    'We have received your report. Details below:',
+    '',
+    divider,
+    `Reference ID: ${p.ref}`,
+    `Received On: ${p.when ?? '—'}`,
+    `Report Type: ${p.issue_type ?? '—'}`,
+    `Target Place ID: ${p.place_ref ?? '—'}`,
+    `Description: ${p.description ?? '—'}`,
+    `Image Count: ${p.images_count ?? 0}`,
+    divider,
+    '',
+    'Our team will review the issue and contact you if necessary.',
+    '',
+    footer,
+  ];
+  return { subject, text: lines.join('\n') };
+}
+
+/* =========================
+ * OPS — REPORT
+ * ========================= */
+function reportOpsReceipt(p: MailPayload): MailContent {
+  ensure(p.ref, 'ref required');
+  const subject = `[OPS] New report received (${p.ref})`;
+  const lines = [
+    `Ref: ${p.ref}`,
+    `When: ${p.when ?? '—'}`,
+    `Submitter: ${p.SubmitterName ?? '—'}${p.SubmitterEmail ? ` <${p.SubmitterEmail}>` : ''}`,
+    `Issue: ${p.issue_type ?? '—'}`,
+    `Target place_ref: ${p.place_ref ?? '—'}`,
+    `Description: ${p.description ?? '—'}`,
+    `Images count: ${p.images_count ?? 0}`,
+  ];
+  return { subject, text: lines.join('\n') };
+}
+
+/* =========================
+ * USER — REPORT RESOLUTION
+ * ========================= */
+function reportUserResolution(p: MailPayload): MailContent {
+  ensure(p.ref, 'ref required');
+  const subject = `[CryptoPayMap] Report Resolution – ${p.resolutionEN ?? 'Resolved'} (Ref: ${p.ref})`;
+  const lines = [
+    `Dear ${p.SubmitterName ?? 'User'},`,
+    '',
+    `Your report (Ref: ${p.ref}) has been processed. Result below:`,
+    '',
+    divider,
+    `Reference ID: ${p.ref}`,
+    `Result: ${p.resolutionEN ?? 'Resolved'}`,
+    `Handled On: ${p.handled_on ?? '—'}`,
+    `Details: ${p.resolution_detail ?? '—'}`,
+    `Related Page: ${p.public_url ?? '—'}`,
+    divider,
+    '',
+    'Thank you for helping improve CryptoPayMap.',
+    '',
+    footer,
+  ];
+  return { subject, text: lines.join('\n') };
+}
+
+/* =========================
+ * PUBLIC API
+ * ========================= */
+export function buildMail(
+  audience: Audience,
+  kind: Kind,
+  action: Action,
+  payload: MailPayload
+): MailContent {
+  // Compatibility guards
+  if (action === 'approved' || action === 'rejected') {
+    if (kind === 'report') throw new Error(`${action} is not valid for kind=report`);
+    if (audience !== 'user') throw new Error(`${action} is only sent to user audience`);
+  }
+  if (action === 'report_resolution') {
+    if (kind !== 'report') throw new Error('report_resolution is only valid for kind=report');
+    if (audience !== 'user') throw new Error('report_resolution is only sent to user audience');
+  }
+
+  // Router
+  if (kind === 'owner' || kind === 'community') {
+    if (action === 'receipt') {
+      return audience === 'ops'
+        ? ocOpsReceipt(kind, payload)
+        : ocUserReceipt(kind, payload);
+    }
+    if (action === 'approved') return ocUserApproved(kind, payload);
+    if (action === 'rejected') return ocUserRejected(kind, payload);
+  } else {
+    // report
+    if (action === 'receipt') {
+      return audience === 'ops' ? reportOpsReceipt(payload) : reportUserReceipt(payload);
+    }
+    if (action === 'report_resolution') {
+      return reportUserResolution(payload);
+    }
+  }
+
+  throw new Error(`Unsupported combination: audience=${audience}, kind=${kind}, action=${action}`);
+}
+
+/* =========================
+ * Example usage
+ * =========================
+ *
+ * import { buildMail } from '@/lib/mailerTemplates';
+ * import { sendMail } from '@/lib/mailer';
+ *
+ * // User (Owner) — receipt
+ * const receiptUser = buildMail('user', 'owner', 'receipt', {
+ *   ref: 'owner-20251021-0001',
+ *   when: '2025-10-21 14:32:55 JST',
+ *   Business: 'South Pole Coffee',
+ *   Country: 'Antarctica',
+ *   City: 'McMurdo Station',
+ *   Category: 'Cafe',
+ *   AcceptedRaw: 'BTC, USDT',
+ *   ImagesCount: 2,
+ *   owner_verify_url: 'https://…/verify/owner-20251021-0001' // optional
+ * });
+ * await sendMail({ to: submitterEmail, subject: receiptUser.subject, text: receiptUser.text });
+ *
+ * // OPS (Owner) — receipt
+ * const receiptOps = buildMail('ops', 'owner', 'receipt', {
+ *   ref: 'owner-20251021-0001',
+ *   when: '2025-10-21 14:32:55 JST',
+ *   Business: 'South Pole Coffee',
+ *   Country: 'Antarctica',
+ *   City: 'McMurdo Station',
+ *   Category: 'Cafe',
+ *   AcceptedRaw: 'BTC, USDT',
+ *   ImagesCount: 2,
+ *   SubmitterName: 'Alice',
+ *   SubmitterEmail: 'owner@example.com',
+ *   owner_verify_url: 'https://…/verify/owner-20251021-0001'
+ * });
+ * await sendMail({ to: 'cryptopaymap.app@gmail.com', subject: receiptOps.subject, text: receiptOps.text });
+ */

--- a/src/lib/ref.ts
+++ b/src/lib/ref.ts
@@ -1,0 +1,10 @@
+// src/lib/ref.ts
+export function makeRef(kind: "owner" | "community" | "report"): string {
+  const pad = (n: number) => String(n).padStart(4, "0");
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const rand = pad(Math.floor(Math.random() * 10000));
+  return `${kind}-${y}${m}${day}-${rand}`;
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -63,6 +63,15 @@ export function sanitizeHeaderValue(input: string | null | undefined, opts?: San
   return s;
 }
 
+/** 簡易メールアドレス検証（空なら "" を返す＝未指定扱い） */
+export function sanitizeEmail(input: string | null | undefined, opts?: SanitizeTextOptions): string {
+  const s = sanitizeText(input ?? "", opts);
+  if (!s) return "";
+  // RFC完全準拠までは不要。実運用レベルの簡易検証。
+  const ok = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+  return ok ? s : "";
+}
+
 /** 非 http(s) / 相対URL / 不正URL を null に */
 export function sanitizeUrl(url: string | null | undefined): string | null {
   if (!url) return null;
@@ -194,6 +203,7 @@ function shortHash(input: string): string {
 export default {
   sanitizeText,
   sanitizeHeaderValue,
+  sanitizeEmail,
   sanitizeUrl,
   normalizeUrl,
   safeFilename,


### PR DESCRIPTION
### Summary

Introduce the mail notification workflow for CryptoPayMap:

* User-facing submission receipts for **Owner / Community / Report** forms
* Operator-triggered notifications for **Approved / Rejected / Report Resolution**

### Changes

* Add centralized email templates and mail transport layer
* Wire submission routes to send confirmation emails (owner/community/report)
* Add OPS notify endpoints for approval, rejection, and report resolution
* Add minimal input sanitization helpers and a small test script

### How to Verify (High Level)

1. Submit each public form (owner / community / report) on the deployed site and confirm:

   * Redirect to `submitted.html?...`
   * User receives a receipt email
   * OPS inbox receives a summary email
2. Call each OPS notify endpoint with a valid auth header and confirm:

   * API returns success
   * User receives the corresponding notification email

### Deployment Notes

* This feature relies on **existing environment configuration managed in Vercel**.
* No secrets are included in this PR; values are already provisioned by OPS.

### Security

* OPS endpoints are protected by a required header key.
* Inputs are sanitized before composing emails.
* No secret values appear in code, logs, or this PR description.

### Impact

* No UI changes; server-side only.
* Automatic deployment should be sufficient; no manual data migration required.

### Risk & Rollback

* Low risk (isolated routes and mailer).
* If issues occur, revert this PR to disable the new endpoints and mail dispatch.

